### PR TITLE
Support MP4 with the "ftypiso5" file header

### DIFF
--- a/SDWebImageVideoCoder/Classes/SDImageVideoCoder.m
+++ b/SDWebImageVideoCoder/Classes/SDImageVideoCoder.m
@@ -46,7 +46,8 @@
         // MPEG4
         NSString *testString = [[NSString alloc] initWithData:[data subdataWithRange:NSMakeRange(4, 8)] encoding:NSASCIIStringEncoding];
         if ([testString isEqualToString:@"ftypMSNV"]
-            || [testString isEqualToString:@"ftypisom"]) {
+            || [testString isEqualToString:@"ftypisom"]
+            || [testString isEqualToString:@"ftypiso5"]) {
             return AVFileTypeMPEG4;
         }
         // M4V


### PR DESCRIPTION
- https://video.twimg.com/tweet_video/GSMiLjRbkAApyqw.mp4

Some GIFV media from Twitter cannot be parsed as MP4 video due to the box container using the "ftypiso5" which the coder does not accept. This patch appends the "ftypiso5" predicate to fix it. Then the Animated Image now playback this GIFV from the URL without issue.

Ref: 
> https://github.com/FFmpeg/FFmpeg/blob/290de647595051034d8f021f24bb4610b2f39943/libavformat/movenc.c#L4945
The FFmpeg writes this major brand for MP4 with `default-base-is-moof` feature flag.